### PR TITLE
Pipe to stdout

### DIFF
--- a/Run_VEP_batch.sh
+++ b/Run_VEP_batch.sh
@@ -77,7 +77,7 @@ if [ ! -f "reference/${fasta}.fa.gz" ]; then
     exit
   else
     wget -P reference http://ftp.ensembl.org/pub/grch37/current/fasta/homo_sapiens/dna/${fasta}.fa.gz
-    gzip -d reference/${fasta}.fa.gz > reference/${fasta}.fa
+    gzip -d -c reference/${fasta}.fa.gz > reference/${fasta}.fa
     bgzip -c reference/${fasta}.fa > reference/${fasta}.fa.gz
   fi
 fi


### PR DESCRIPTION
During unzipping the fasta reference the gzip command requires user interaction returning the following prompt:
gzip: reference/Homo_sapiens.GRCh37.dna.primary_assembly.fa already exists; do you wish to overwrite (y or n)?

This happens as gzip already creates the output file during unzipping by default.
In some cases this leads to an empty fasta-file as gzip does not write any output to stdout.

To solve this one can choose to not pipe to a file or alternatively add the -c parameter for writing to stdout.